### PR TITLE
next.config.mjs: Allow deployment to non-root environments

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "export",
+  basePath: '/interactives/2024/fg-testing', // if deploying to the NI test env
+  // basePath: '/interactives/2024/fertile-ground', // if deploying to the NI test env
 };
 export default nextConfig;


### PR DESCRIPTION
When next js builds it assumes that we will be serving from the root of the server and constructs URLS accordingly i.e. 

/_next/somefile

But in NI's case we want to serve from a subdirectory, and the files live at:

/interactives/2024/fertile-ground/_next/somefile

This PR adds a default basePath for our production and live envs. Comment out if deploying to vercel.